### PR TITLE
Allow usage of different file extensions via option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,8 @@ const htmlminifier = {
 
 const defaultoptions = {
   htmlminifier: htmlminifier,
-  literals: false
+  literals: false,
+  includeExtension: ['.js']
 }
 
 export default function minifyliterals (options = {}) {
@@ -24,7 +25,9 @@ export default function minifyliterals (options = {}) {
     name: 'minifyliterals',
 
     transform (code, id) {
-      if (!filter(id) || extname(id) !== '.js') return
+      if (!filter(id) || options.includeExtension.indexOf(extname(id)) === -1) {
+        return;
+      }
 
       let ast
 


### PR DESCRIPTION
Introduces `options.includeExtension` as Array of file extensions which will be included.
Useful if processing Typescript or JSX sources, whose filenames will still have their original extension when compiled via rollup plugin.

Example:
```js
        ...
        minifyLit({
            includeExtension: ['.ts', '.js'],
            htmlminifier: {
                collapseWhitespace: true
            }
        }),
        ...
```