### PR TITLE
Use algorithm to minify whole templates with replaced expressions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import { walk } from 'estree-walker'
 import MagicString from 'magic-string'
 import { createFilter } from 'rollup-pluginutils'
 import { minify } from 'html-minifier'
+import { MinifyTemplate } from "./minify-templates";
 
 const htmlminifier = {
   collapseWhitespace: true
@@ -39,6 +40,7 @@ export default function minifyliterals (options = {}) {
       }
 
       const magicString = new MagicString(code)
+      const minifyTemplates = new MinifyTemplate(code, magicString, options.htmlminifier)
       let edited = false
 
       walk(ast, {
@@ -49,10 +51,8 @@ export default function minifyliterals (options = {}) {
             magicString.addSourcemapLocation(node.start)
             magicString.addSourcemapLocation(node.end)
           }
-          if (node.type === 'TemplateElement') {
-            value = node.value.raw
-            transformed = minify(value, options.htmlminifier)
-          }
+
+          minifyTemplates.enter(node);
 
           if (node.type === 'Literal' && options.literals !== false) {
             value = node.raw
@@ -88,8 +88,14 @@ export default function minifyliterals (options = {}) {
             edited = true
             magicString.overwrite(node.start, node.end, transformed)
           }
+        },
+
+        leave (node) {
+          minifyTemplates.leave(node);
         }
       })
+
+      edited = edited || minifyTemplates.edited
 
       if (!edited) return null
       code = magicString.toString()

--- a/src/minify-templates.js
+++ b/src/minify-templates.js
@@ -1,0 +1,112 @@
+import { minify } from 'html-minifier'
+
+const expressionPlaceholder = '--MINIFYLITEXPRESSION--';
+const expressionPlaceholderMatcher = new RegExp(expressionPlaceholder, 'g');
+
+function mapStack(stack) {
+    return stack.map(item => Object.assign({}, item, { node: item.node.type }));
+}
+
+export class MinifyTemplate {
+    constructor(code, output, options) {
+        // args
+        this.code = code;
+        this.magicString = output;
+        this.options = options;
+
+        // algo
+        this._inTemplateLiteral = false;
+        this.MainStack = [];
+        this.ExpressionStack = [];
+        this.ResultStack = [];
+
+        // state
+        this._edited = false;
+    }
+
+    enter(node) {
+        if(node.type === 'TemplateElement') {
+            if(this.MainStack.length === 0) {
+                throw new Error("Encountered TemplateElement outside of TemplateLiteral. Not implemented.");
+            }
+
+            this.MainStack[this.MainStack.length-1].stack.push(node);
+            return;
+        }
+
+        if(this._inTemplateLiteral) {
+            this._inTemplateLiteral = false;
+            this.ExpressionStack.push({
+                node,
+                hasTemplateChild: false
+            });
+        }
+
+        if(node.type === 'TemplateLiteral') {
+            this._inTemplateLiteral = true;
+            this.MainStack.push({
+                node,
+                stack: []
+            });
+            if(this.ExpressionStack.length > 0) {
+                this.ExpressionStack[this.ExpressionStack.length-1].hasTemplateChild = true;
+            }
+        }
+    }
+
+    leave(node) {
+        if(node.type === 'TemplateLiteral') {
+            this._inTemplateLiteral = false;
+            const currentLiteral = this.MainStack.pop();
+            if(currentLiteral.node !== node) {
+                throw new Error("Left a TemplateLiteral that was not on top of the MainStack. Not implemented.");
+            }
+
+            const value = currentLiteral.stack.reverse().map(node => node.value.raw).join(expressionPlaceholder);
+            const transformed = "`" + minify(value, this.options) + "`";
+            const output = transformed.replace(expressionPlaceholderMatcher, match => {
+                if(this.ResultStack.length === 0) {
+                    throw new Error("No Expression found for Replacement. Unexpected.");
+                }
+                return this.ResultStack.pop().value;
+            });
+
+            if(this.MainStack.length > 0) {
+                this.ResultStack.push({
+                    node,
+                    value: output
+                });
+            } else {
+                this._edited = true;
+                this.magicString.overwrite(node.start, node.end, output);
+            }
+        }
+
+        if(this.ExpressionStack.length > 0 && this.ExpressionStack[this.ExpressionStack.length-1].node === node) {
+            this._inTemplateLiteral = true;
+            const currentExpression = this.ExpressionStack.pop();
+
+            let exprValue = "";
+            if(!currentExpression.hasTemplateChild) {
+                exprValue = "${" + this.code.substring(node.start, node.end) + "}";
+            } else {
+                const templateResult = this.ResultStack.pop();
+                exprValue =
+                    "${" +
+                    this.code.substring(node.start, templateResult.node.start) +
+                    templateResult.value +
+                    this.code.substring(templateResult.node.end, node.end) +
+                    "}";
+            }
+
+            this.ResultStack.push({
+                node,
+                value: exprValue
+            });
+        }
+    }
+
+    get edited() {
+        return this._edited;
+    }
+}

--- a/test/fixtures/nested-templates/input.js
+++ b/test/fixtures/nested-templates/input.js
@@ -1,0 +1,14 @@
+const str = html`
+<a href="${"something"}">
+    ${['hello', 'world'].map(i => html`
+        <p>
+            ${i}
+        </p>
+    `)}
+</a>
+${1+2}
+
+<hr>
+
+<span>${true ? html`you sure? ${'no'}` : ""}</span>
+`

--- a/test/fixtures/nested-templates/output.js
+++ b/test/fixtures/nested-templates/output.js
@@ -1,0 +1,1 @@
+const str = html`<a href="${"something"}">${['hello', 'world'].map(i => html`<p>${i}</p>`)} </a>${1+2}<hr><span>${true ? html`you sure? ${'no'}` : ""}</span>`

--- a/test/stripliteralls.test.js
+++ b/test/stripliteralls.test.js
@@ -25,6 +25,11 @@ test('removes whitespace from Literal nodes', t => {
   t.deepEqual(actual, expected)
 })
 
+test('handles nested templates correctly', t => {
+    let { actual, expected } = compare('literal', extraoptions)
+    t.deepEqual(actual, expected)
+})
+
 test('returns null if no changes were made', t => {
   t.is(transform('ast/output.js'), null)
 })


### PR DESCRIPTION
`html-minify` is really bad with partial html elements produced by expressions in attributes or as inline-element children.
This approach minifies a template literal as a whole after replacing expressions by a placeholder to allow all kinds of quotes in expressions.

This is based on a stack-based iterative algorithm which uses the estree walkthrough.